### PR TITLE
URL Cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,7 +195,7 @@
 		<repository>
 			<id>spring-libs-snapshot</id>
 			<name>Spring project release, milestone, and snapshot artifacts and transitive dependencies</name>
-			<url>http://repo.springsource.org/libs-snapshot</url>
+			<url>https://repo.springsource.org/libs-snapshot</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://repo.springsource.org/libs-snapshot migrated to:  
  https://repo.springsource.org/libs-snapshot ([https](https://repo.springsource.org/libs-snapshot) result 301).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/xsd/maven-4.0.0.xsd
* http://www.w3.org/2001/XMLSchema-instance