### PR TITLE
URL Cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.springframework</groupId>
 	<artifactId>spring-test-mvc</artifactId>
@@ -195,7 +195,7 @@
 		<repository>
 			<id>spring-libs-snapshot</id>
 			<name>Spring project release, milestone, and snapshot artifacts and transitive dependencies</name>
-			<url>http://repo.springsource.org/libs-snapshot</url>
+			<url>https://repo.springsource.org/libs-snapshot</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>

--- a/src/test/resources/META-INF/web-resources/WEB-INF/layouts/tiles.xml
+++ b/src/test/resources/META-INF/web-resources/WEB-INF/layouts/tiles.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE tiles-definitions PUBLIC "-//Apache Software Foundation//DTD Tiles Configuration 2.1//EN" "http://tiles.apache.org/dtds/tiles-config_2_1.dtd">
+<!DOCTYPE tiles-definitions PUBLIC "-//Apache Software Foundation//DTD Tiles Configuration 2.1//EN" "https://tiles.apache.org/dtds/tiles-config_2_1.dtd">
 
 <tiles-definitions>
 

--- a/src/test/resources/META-INF/web-resources/WEB-INF/views/tiles.xml
+++ b/src/test/resources/META-INF/web-resources/WEB-INF/views/tiles.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE tiles-definitions PUBLIC "-//Apache Software Foundation//DTD Tiles Configuration 2.1//EN" "http://tiles.apache.org/dtds/tiles-config_2_1.dtd">
+<!DOCTYPE tiles-definitions PUBLIC "-//Apache Software Foundation//DTD Tiles Configuration 2.1//EN" "https://tiles.apache.org/dtds/tiles-config_2_1.dtd">
 
 <tiles-definitions>
 

--- a/src/test/resources/org/springframework/test/web/server/samples/context/TestContextTests-context.xml
+++ b/src/test/resources/org/springframework/test/web/server/samples/context/TestContextTests-context.xml
@@ -3,8 +3,8 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:beans="http://www.springframework.org/schema/beans"
 	xsi:schemaLocation="
-		http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<annotation-driven />
 

--- a/src/test/resources/org/springframework/test/web/server/samples/context/security.xml
+++ b/src/test/resources/org/springframework/test/web/server/samples/context/security.xml
@@ -1,8 +1,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns="http://www.springframework.org/schema/security"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.1.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security-3.1.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
 
 	<http auto-config="true" use-expressions="true">
 		<intercept-url pattern="/**" access="hasRole('ROLE_USER')" />

--- a/src/test/resources/org/springframework/test/web/server/samples/servlet-context.xml
+++ b/src/test/resources/org/springframework/test/web/server/samples/servlet-context.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:mvc="http://www.springframework.org/schema/mvc"
     xsi:schemaLocation="
-		http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc-3.1.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
+		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc-3.1.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
 
     <mvc:annotation-driven />
 

--- a/src/test/webapp/WEB-INF/layouts/tiles.xml
+++ b/src/test/webapp/WEB-INF/layouts/tiles.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE tiles-definitions PUBLIC "-//Apache Software Foundation//DTD Tiles Configuration 2.1//EN" "http://tiles.apache.org/dtds/tiles-config_2_1.dtd">
+<!DOCTYPE tiles-definitions PUBLIC "-//Apache Software Foundation//DTD Tiles Configuration 2.1//EN" "https://tiles.apache.org/dtds/tiles-config_2_1.dtd">
 
 <tiles-definitions>
 

--- a/src/test/webapp/WEB-INF/views/tiles.xml
+++ b/src/test/webapp/WEB-INF/views/tiles.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE tiles-definitions PUBLIC "-//Apache Software Foundation//DTD Tiles Configuration 2.1//EN" "http://tiles.apache.org/dtds/tiles-config_2_1.dtd">
+<!DOCTYPE tiles-definitions PUBLIC "-//Apache Software Foundation//DTD Tiles Configuration 2.1//EN" "https://tiles.apache.org/dtds/tiles-config_2_1.dtd">
 
 <tiles-definitions>
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://maven.apache.org/xsd/maven-4.0.0.xsd with 1 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).
* http://tiles.apache.org/dtds/tiles-config_2_1.dtd with 4 occurrences migrated to:  
  https://tiles.apache.org/dtds/tiles-config_2_1.dtd ([https](https://tiles.apache.org/dtds/tiles-config_2_1.dtd) result 200).
* http://www.springframework.org/schema/beans/spring-beans-3.0.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans-3.0.xsd ([https](https://www.springframework.org/schema/beans/spring-beans-3.0.xsd) result 200).
* http://www.springframework.org/schema/beans/spring-beans-3.1.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans-3.1.xsd ([https](https://www.springframework.org/schema/beans/spring-beans-3.1.xsd) result 200).
* http://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd ([https](https://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd) result 200).
* http://www.springframework.org/schema/mvc/spring-mvc-3.1.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/mvc/spring-mvc-3.1.xsd ([https](https://www.springframework.org/schema/mvc/spring-mvc-3.1.xsd) result 200).
* http://www.springframework.org/schema/security/spring-security-3.1.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/security/spring-security-3.1.xsd ([https](https://www.springframework.org/schema/security/spring-security-3.1.xsd) result 200).
* http://repo.springsource.org/libs-snapshot with 1 occurrences migrated to:  
  https://repo.springsource.org/libs-snapshot ([https](https://repo.springsource.org/libs-snapshot) result 301).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0 with 2 occurrences
* http://www.springframework.org/schema/beans with 6 occurrences
* http://www.springframework.org/schema/mvc with 4 occurrences
* http://www.springframework.org/schema/security with 2 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 4 occurrences