### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 
 This project facilitates testing _Spring MVC_ server-side and client-side _RestTemplate_-based code.
 
-__NOTE: The project is now incorporated in the spring-test module of Spring Framework 3.2. Applications building against Spring Framework 3.1.x can continue to use this standalone project. However, applications building with Spring Framework 3.2 should use the spring-test module of Spring Framework 3.2 instead. See the Spring Framework [reference guide](http://static.springsource.org/spring-framework/docs/3.2.0.BUILD-SNAPSHOT/reference/htmlsingle/#spring-mvc-test-framework) for more details.__
+__NOTE: The project is now incorporated in the spring-test module of Spring Framework 3.2. Applications building against Spring Framework 3.1.x can continue to use this standalone project. However, applications building with Spring Framework 3.2 should use the spring-test module of Spring Framework 3.2 instead. See the Spring Framework [reference guide](https://docs.spring.io/spring-framework/docs/3.2.0.BUILD-SNAPSHOT/reference/htmlsingle/#spring-mvc-test-framework) for more details.__
 
 To get started, see sample [server-side](spring-test-mvc/tree/master/src/test/java/org/springframework/test/web/server/samples) and [client-side](spring-test-mvc/tree/master/src/test/java/org/springframework/test/web/client/samples) tests. The [spring-mvc-showcase](https://github.com/SpringSource/spring-mvc-showcase) project also has many sample tests.
 
 Milestone 2 can be obtained through the
-http://repo.springsource.org/libs-milestone repository.
+https://repo.springsource.org/libs-milestone repository.
 
     <dependency>
       <groupId>org.springframework</groupId>
@@ -15,7 +15,7 @@ http://repo.springsource.org/libs-milestone repository.
       <scope>test</scope>
     </dependency>
 
-The latest snapshot can be obtained through the http://repo.springsource.org/libs-snapshot repository.
+The latest snapshot can be obtained through the https://repo.springsource.org/libs-snapshot repository.
 
     <dependency>
       <groupId>org.springframework</groupId>

--- a/src/main/java/org/springframework/test/web/client/match/ContentRequestMatchers.java
+++ b/src/main/java/org/springframework/test/web/client/match/ContentRequestMatchers.java
@@ -137,7 +137,7 @@ public class ContentRequestMatchers {
 
 	/**
 	 * Parse the request content as {@link DOMSource} and apply the given {@link Matcher}.
-	 * @see <a href="http://code.google.com/p/xml-matchers/">http://code.google.com/p/xml-matchers/</a>
+	 * @see <a href="https://code.google.com/p/xml-matchers/">https://code.google.com/p/xml-matchers/</a>
 	 */
 	public RequestMatcher source(final Matcher<? super Source> matcher) {
 		return new AbstractXmlRequestMatcher() {

--- a/src/main/java/org/springframework/test/web/client/match/JsonPathRequestMatchers.java
+++ b/src/main/java/org/springframework/test/web/client/match/JsonPathRequestMatchers.java
@@ -30,7 +30,7 @@ import org.springframework.test.web.support.JsonPathExpectationsHelper;
 
 /**
  * Factory methods for request content {@code RequestMatcher}'s using a <a
- * href="http://goessner.net/articles/JsonPath/">JSONPath</a> expression.
+ * href="https://goessner.net/articles/JsonPath/">JSONPath</a> expression.
  * An instance of this class is typically accessed via
  * {@code RequestMatchers.jsonPath(..)}.
  *

--- a/src/main/java/org/springframework/test/web/client/match/RequestMatchers.java
+++ b/src/main/java/org/springframework/test/web/client/match/RequestMatchers.java
@@ -159,7 +159,7 @@ public abstract class RequestMatchers {
 
 	/**
 	 * Access to request body matchers using a <a
-	 * href="http://goessner.net/articles/JsonPath/">JSONPath</a> expression to
+	 * href="https://goessner.net/articles/JsonPath/">JSONPath</a> expression to
 	 * inspect a specific subset of the body. The JSON path expression can be a
 	 * parameterized string using formatting specifiers as defined in
 	 * {@link String#format(String, Object...)}.
@@ -173,7 +173,7 @@ public abstract class RequestMatchers {
 
 	/**
 	 * Access to request body matchers using a <a
-	 * href="http://goessner.net/articles/JsonPath/">JSONPath</a> expression to
+	 * href="https://goessner.net/articles/JsonPath/">JSONPath</a> expression to
 	 * inspect a specific subset of the body and a Hamcrest match for asserting
 	 * the value found at the JSON path.
 	 *

--- a/src/main/java/org/springframework/test/web/server/request/MockHttpServletRequestBuilder.java
+++ b/src/main/java/org/springframework/test/web/server/request/MockHttpServletRequestBuilder.java
@@ -325,7 +325,7 @@ public class MockHttpServletRequestBuilder implements RequestBuilder, Mergeable 
 	 * path must start with a "/" and must not end with a "/".
 	 *
 	 * @see <a
-	 * href="http://docs.oracle.com/javaee/6/api/javax/servlet/http/HttpServletRequest.html#getContextPath%28%29">HttpServletRequest.getContextPath()</a>
+	 * href="https://docs.oracle.com/javaee/6/api/javax/servlet/http/HttpServletRequest.html#getContextPath%28%29">HttpServletRequest.getContextPath()</a>
 	 */
 	public MockHttpServletRequestBuilder contextPath(String contextPath) {
 		if (StringUtils.hasText(contextPath)) {
@@ -350,7 +350,7 @@ public class MockHttpServletRequestBuilder implements RequestBuilder, Mergeable 
 	 * end with a "/".
 	 *
 	 * @see <a
-	 * href="http://docs.oracle.com/javaee/6/api/javax/servlet/http/HttpServletRequest.html#getServletPath%28%29">HttpServletRequest.getServletPath()</a>
+	 * href="https://docs.oracle.com/javaee/6/api/javax/servlet/http/HttpServletRequest.html#getServletPath%28%29">HttpServletRequest.getServletPath()</a>
 	 */
 	public MockHttpServletRequestBuilder servletPath(String servletPath) {
 		if (StringUtils.hasText(servletPath)) {
@@ -372,7 +372,7 @@ public class MockHttpServletRequestBuilder implements RequestBuilder, Mergeable 
 	 * <p>If specified, the pathInfo will be used as is.
 	 *
 	 * @see <a
-	 * href="http://docs.oracle.com/javaee/6/api/javax/servlet/http/HttpServletRequest.html#getPathInfo%28%29">HttpServletRequest.getServletPath()</a>
+	 * href="https://docs.oracle.com/javaee/6/api/javax/servlet/http/HttpServletRequest.html#getPathInfo%28%29">HttpServletRequest.getServletPath()</a>
 	 */
 	public MockHttpServletRequestBuilder pathInfo(String pathInfo) {
 		if (StringUtils.hasText(pathInfo)) {

--- a/src/main/java/org/springframework/test/web/server/result/ContentResultMatchers.java
+++ b/src/main/java/org/springframework/test/web/server/result/ContentResultMatchers.java
@@ -163,7 +163,7 @@ public class ContentResultMatchers {
 	 * Parse the response content as {@link DOMSource} and apply the given
 	 * Hamcrest {@link Matcher}.
 	 *
-	 * @see <a href="http://code.google.com/p/xml-matchers/">xml-matchers</a>
+	 * @see <a href="https://code.google.com/p/xml-matchers/">xml-matchers</a>
 	 */
 	public ResultMatcher source(final Matcher<? super Source> matcher) {
 		return new ResultMatcher() {

--- a/src/main/java/org/springframework/test/web/server/result/JsonPathResultMatchers.java
+++ b/src/main/java/org/springframework/test/web/server/result/JsonPathResultMatchers.java
@@ -28,7 +28,7 @@ import org.springframework.test.web.support.JsonPathExpectationsHelper;
 
 /**
  * Factory for assertions on the response content using <a
- * href="http://goessner.net/articles/JsonPath/">JSONPath</a> expressions.
+ * href="https://goessner.net/articles/JsonPath/">JSONPath</a> expressions.
  * An instance of this class is typically accessed via
  * {@link MockMvcResultMatchers#jsonPpath}.
  *

--- a/src/main/java/org/springframework/test/web/server/result/MockMvcResultMatchers.java
+++ b/src/main/java/org/springframework/test/web/server/result/MockMvcResultMatchers.java
@@ -120,7 +120,7 @@ public abstract class MockMvcResultMatchers {
 
 	/**
 	 * Access to response body assertions using a <a
-	 * href="http://goessner.net/articles/JsonPath/">JSONPath</a> expression to
+	 * href="https://goessner.net/articles/JsonPath/">JSONPath</a> expression to
 	 * inspect a specific subset of the body. The JSON path expression can be a
 	 * parameterized string using formatting specifiers as defined in
 	 * {@link String#format(String, Object...)}.
@@ -134,7 +134,7 @@ public abstract class MockMvcResultMatchers {
 
 	/**
 	 * Access to response body assertions using a <a
-	 * href="http://goessner.net/articles/JsonPath/">JSONPath</a> expression to
+	 * href="https://goessner.net/articles/JsonPath/">JSONPath</a> expression to
 	 * inspect a specific subset of the body and a Hamcrest match for asserting
 	 * the value found at the JSON path.
 	 *

--- a/src/main/java/org/springframework/test/web/support/XmlExpectationsHelper.java
+++ b/src/main/java/org/springframework/test/web/support/XmlExpectationsHelper.java
@@ -62,7 +62,7 @@ public class XmlExpectationsHelper {
 
 	/**
 	 * Parse the content as {@link DOMSource} and apply a {@link Matcher}.
-	 * @see <a href="http://code.google.com/p/xml-matchers/">xml-matchers</a>
+	 * @see <a href="https://code.google.com/p/xml-matchers/">xml-matchers</a>
 	 */
 	public void assertSource(String content, Matcher<? super Source> matcher) throws Exception {
 		Document document = parseXmlString(content);

--- a/src/test/java/org/springframework/test/web/client/match/RequestMatchersTests.java
+++ b/src/test/java/org/springframework/test/web/client/match/RequestMatchersTests.java
@@ -42,21 +42,21 @@ public class RequestMatchersTests {
 
 	@Test
 	public void requestTo() throws Exception {
-		this.request.setURI(new URI("http://foo.com/bar"));
+		this.request.setURI(new URI("http://www.foo.com/bar"));
 
-		RequestMatchers.requestTo("http://foo.com/bar").match(this.request);
+		RequestMatchers.requestTo("http://www.foo.com/bar").match(this.request);
 	}
 
 	@Test(expected=AssertionError.class)
 	public void requestToNoMatch() throws Exception {
-		this.request.setURI(new URI("http://foo.com/bar"));
+		this.request.setURI(new URI("http://www.foo.com/bar"));
 
-		RequestMatchers.requestTo("http://foo.com/wrong").match(this.request);
+		RequestMatchers.requestTo("http://www.foo.com/wrong").match(this.request);
 	}
 
 	@Test
 	public void requestToContains() throws Exception {
-		this.request.setURI(new URI("http://foo.com/bar"));
+		this.request.setURI(new URI("http://www.foo.com/bar"));
 
 		RequestMatchers.requestTo(containsString("bar")).match(this.request);
 	}

--- a/src/test/java/org/springframework/test/web/client/samples/matchers/JsonPathRequestMatcherTests.java
+++ b/src/test/java/org/springframework/test/web/client/samples/matchers/JsonPathRequestMatcherTests.java
@@ -42,7 +42,7 @@ import org.springframework.web.client.RestTemplate;
 
 /**
  * Examples of defining expectations on JSON request content with
- * <a href="http://goessner.net/articles/JsonPath/">JSONPath</a> expressions.
+ * <a href="https://goessner.net/articles/JsonPath/">JSONPath</a> expressions.
  *
  * @author Rossen Stoyanchev
  */

--- a/src/test/java/org/springframework/test/web/client/samples/matchers/XpathRequestMatcherTests.java
+++ b/src/test/java/org/springframework/test/web/client/samples/matchers/XpathRequestMatcherTests.java
@@ -58,7 +58,7 @@ import org.springframework.web.client.RestTemplate;
 public class XpathRequestMatcherTests {
 
 	private static final Map<String, String> NS =
-			Collections.singletonMap("ns", "http://example.org/music/people");
+			Collections.singletonMap("ns", "https://example.org/music/people");
 
 	private MockRestServiceServer mockServer;
 
@@ -202,7 +202,7 @@ public class XpathRequestMatcherTests {
 
 
 	@SuppressWarnings("unused")
-	@XmlRootElement(name="people", namespace="http://example.org/music/people")
+	@XmlRootElement(name="people", namespace="https://example.org/music/people")
 	@XmlAccessorType(XmlAccessType.FIELD)
 	private static class PeopleWrapper {
 

--- a/src/test/java/org/springframework/test/web/server/samples/standalone/resultmatchers/FlashAttributeAssertionTests.java
+++ b/src/test/java/org/springframework/test/web/server/samples/standalone/resultmatchers/FlashAttributeAssertionTests.java
@@ -64,10 +64,10 @@ public class FlashAttributeAssertionTests {
 		this.mockMvc.perform(post("/persons"))
             .andExpect(flash().attribute("one", "1"))
             .andExpect(flash().attribute("two", 2.222))
-            .andExpect(flash().attribute("three", new URL("http://example.com")))
+            .andExpect(flash().attribute("three", new URL("https://example.com")))
 	        .andExpect(flash().attribute("one", equalTo("1")))	// Hamcrest...
 	        .andExpect(flash().attribute("two", equalTo(2.222)))
-	        .andExpect(flash().attribute("three", equalTo(new URL("http://example.com"))));
+	        .andExpect(flash().attribute("three", equalTo(new URL("https://example.com"))));
 	}
 
 	@Test
@@ -86,7 +86,7 @@ public class FlashAttributeAssertionTests {
 		public String save(RedirectAttributes redirectAttrs) throws Exception {
 			redirectAttrs.addFlashAttribute("one", "1");
 			redirectAttrs.addFlashAttribute("two", 2.222);
-			redirectAttrs.addFlashAttribute("three", new URL("http://example.com"));
+			redirectAttrs.addFlashAttribute("three", new URL("https://example.com"));
 			return "redirect:/person/1";
 		}
 	}

--- a/src/test/java/org/springframework/test/web/server/samples/standalone/resultmatchers/JsonPathAssertionTests.java
+++ b/src/test/java/org/springframework/test/web/server/samples/standalone/resultmatchers/JsonPathAssertionTests.java
@@ -42,7 +42,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 
 /**
  * Examples of defining expectations on JSON response content with
- * <a href="http://goessner.net/articles/JsonPath/">JSONPath</a> expressions.
+ * <a href="https://goessner.net/articles/JsonPath/">JSONPath</a> expressions.
  *
  * @author Rossen Stoyanchev
  *

--- a/src/test/java/org/springframework/test/web/server/samples/standalone/resultmatchers/XpathAssertionTests.java
+++ b/src/test/java/org/springframework/test/web/server/samples/standalone/resultmatchers/XpathAssertionTests.java
@@ -54,7 +54,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 public class XpathAssertionTests {
 
 	private static final Map<String, String> NS =
-		Collections.singletonMap("ns", "http://example.org/music/people");
+		Collections.singletonMap("ns", "https://example.org/music/people");
 
 	private MockMvc mockMvc;
 
@@ -170,7 +170,7 @@ public class XpathAssertionTests {
 	}
 
 	@SuppressWarnings("unused")
-	@XmlRootElement(name="people", namespace="http://example.org/music/people")
+	@XmlRootElement(name="people", namespace="https://example.org/music/people")
 	@XmlAccessorType(XmlAccessType.FIELD)
 	private static class PeopleWrapper {
 

--- a/src/test/resources/META-INF/web-resources/WEB-INF/layouts/standardLayout.jsp
+++ b/src/test/resources/META-INF/web-resources/WEB-INF/layouts/standardLayout.jsp
@@ -1,6 +1,6 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ taglib uri="http://tiles.apache.org/tags-tiles" prefix="tiles" %>
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">

--- a/src/test/webapp/WEB-INF/layouts/main.jsp
+++ b/src/test/webapp/WEB-INF/layouts/main.jsp
@@ -1,6 +1,6 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8"
     pageEncoding="UTF-8"%>
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://xmlunit.sourceforge.net/ (200) with 3 occurrences could not be migrated:  
   ([https](https://xmlunit.sourceforge.net/) result AnnotatedConnectException).
* [ ] http://foo.com/bar (301) with 4 occurrences could not be migrated:  
   ([https](https://foo.com/bar) result SSLHandshakeException).
* [ ] http://foo.com/wrong (301) with 1 occurrences could not be migrated:  
   ([https](https://foo.com/wrong) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://www.w3.org/TR/html4/loose.dtd (ReadTimeoutException) with 2 occurrences migrated to:  
  https://www.w3.org/TR/html4/loose.dtd ([https](https://www.w3.org/TR/html4/loose.dtd) result SSLException).
* [ ] http://static.springsource.org/spring-framework/docs/3.2.0.BUILD-SNAPSHOT/reference/htmlsingle/ (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-framework/docs/3.2.0.BUILD-SNAPSHOT/reference/htmlsingle/ ([https](https://static.springsource.org/spring-framework/docs/3.2.0.BUILD-SNAPSHOT/reference/htmlsingle/) result 404).
* [ ] http://example.org/music/people (404) with 4 occurrences migrated to:  
  https://example.org/music/people ([https](https://example.org/music/people) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://docs.oracle.com/javaee/6/api/javax/servlet/http/HttpServletRequest.html with 3 occurrences migrated to:  
  https://docs.oracle.com/javaee/6/api/javax/servlet/http/HttpServletRequest.html ([https](https://docs.oracle.com/javaee/6/api/javax/servlet/http/HttpServletRequest.html) result 200).
* [ ] http://example.com with 3 occurrences migrated to:  
  https://example.com ([https](https://example.com) result 200).
* [ ] http://goessner.net/articles/JsonPath/ with 8 occurrences migrated to:  
  https://goessner.net/articles/JsonPath/ ([https](https://goessner.net/articles/JsonPath/) result 200).
* [ ] http://code.google.com/p/xml-matchers/ with 4 occurrences migrated to:  
  https://code.google.com/p/xml-matchers/ ([https](https://code.google.com/p/xml-matchers/) result 301).
* [ ] http://repo.springsource.org/libs-milestone with 1 occurrences migrated to:  
  https://repo.springsource.org/libs-milestone ([https](https://repo.springsource.org/libs-milestone) result 301).
* [ ] http://repo.springsource.org/libs-snapshot with 1 occurrences migrated to:  
  https://repo.springsource.org/libs-snapshot ([https](https://repo.springsource.org/libs-snapshot) result 301).

# Ignored
These URLs were intentionally ignored.

* http://localhost/spring_security_login with 1 occurrences
* http://tiles.apache.org/tags-tiles with 1 occurrences